### PR TITLE
Rename artifact id and remove class variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,22 +72,18 @@ pip install hypha-artifact
 
 ## Quick Start
 
-### Basic Setup
+### Synchronous Version
 
 ```python
 from hypha_artifact import HyphaArtifact
 
 # Initialize with your credentials
 artifact = HyphaArtifact(
-    artifact_name="my-artifact",
+    artifact_id="my-artifact",
     workspace="your-workspace-id", 
     token="your-personal-token"
 )
-```
 
-### Basic File Operations
-
-```python
 # Create and write to a file
 with artifact.open("hello.txt", "w") as f:
     f.write("Hello, Hypha!")
@@ -111,6 +107,46 @@ artifact.copy("hello.txt", "hello_copy.txt")
 artifact.rm("hello_copy.txt")
 ```
 
+### Asynchronous Version (Recommended)
+
+```python
+import asyncio
+from hypha_artifact import AsyncHyphaArtifact
+
+async def main():
+    # Initialize and use as context manager
+    async with AsyncHyphaArtifact(
+        artifact_id="my-artifact",
+        workspace="your-workspace-id", 
+        token="your-personal-token"
+    ) as artifact:
+        
+        # Create and write to a file
+        async with artifact.open("hello.txt", "w") as f:
+            await f.write("Hello, Hypha!")
+        
+        # Read file content
+        content = await artifact.cat("hello.txt")
+        print(content)  # Output: Hello, Hypha!
+        
+        # List files in the artifact
+        files = await artifact.ls("/")
+        print([f["name"] for f in files])
+        
+        # Check if file exists
+        if await artifact.exists("hello.txt"):
+            print("File exists!")
+        
+        # Copy a file
+        await artifact.copy("hello.txt", "hello_copy.txt")
+        
+        # Remove a file
+        await artifact.rm("hello_copy.txt")
+
+# Run the async function
+asyncio.run(main())
+```
+
 ## API Reference
 
 ### Synchronous API
@@ -120,7 +156,7 @@ The `HyphaArtifact` class provides synchronous file operations:
 #### Initialization
 
 ```python
-HyphaArtifact(artifact_name: str, workspace: str, token: str)
+HyphaArtifact(artifact_id: str, workspace: str, token: str)
 ```
 
 #### File Operations
@@ -185,7 +221,7 @@ The `AsyncHyphaArtifact` class provides asynchronous file operations for better 
 from hypha_artifact import AsyncHyphaArtifact
 
 async_artifact = AsyncHyphaArtifact(
-    artifact_name="my-artifact",
+    artifact_id="my-artifact",
     workspace="workspace-id",
     token="your-token"
 )
@@ -210,14 +246,13 @@ from hypha_artifact import AsyncHyphaArtifact
 
 async def main():
     # Method 1: Manual connection management
-    artifact = AsyncHyphaArtifact("my-artifact", "workspace", "token")
+    artifact = AsyncHyphaArtifact("my-workspace/my-artifact", token="token")
     
-    async with artifact:
-        async with artifact.open("async_file.txt", "w") as f:
-            await f.write("Async content")
-        
-        content = await artifact.cat("async_file.txt")
-        print(content)
+    async with artifact.open("async_file.txt", "w") as f:
+        await f.write("Async content")
+    
+    content = await artifact.cat("async_file.txt")
+    print(content)
     
     # Method 2: Context manager for the entire artifact
     async with AsyncHyphaArtifact("my-artifact", "workspace", "token") as artifact:

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ from hypha_artifact import HyphaArtifact
 artifact = HyphaArtifact(
     artifact_id="my-artifact",
     workspace="your-workspace-id", 
-    token="your-personal-token"
+    token="your-workspace-token"
 )
 
 # Create and write to a file
@@ -118,7 +118,7 @@ async def main():
     async with AsyncHyphaArtifact(
         artifact_id="my-artifact",
         workspace="your-workspace-id", 
-        token="your-personal-token"
+        token="your-workspace-token"
     ) as artifact:
         
         # Create and write to a file

--- a/hypha_artifact/async_hypha_artifact.py
+++ b/hypha_artifact/async_hypha_artifact.py
@@ -38,7 +38,7 @@ class AsyncHyphaArtifact:
         The base URL for the Hypha artifact manager service.
     token : str
         The authentication token for accessing the artifact service.
-    workspace_id : str
+    workspace : str
         The workspace identifier associated with the artifact.
 
     Examples
@@ -59,12 +59,7 @@ class AsyncHyphaArtifact:
     ...     await artifact.aclose()
     """
 
-    artifact_alias: str
-    artifact_url: str
-    token: str
-    workspace_id: str
-
-    def __init__(self: Self, artifact_alias: str, workspace: str, token: str):
+    def __init__(self: Self, artifact_id: str, workspace: str, token: str=None, service_url: str=None):
         """Initialize an AsyncHyphaArtifact instance.
 
         Parameters
@@ -72,10 +67,18 @@ class AsyncHyphaArtifact:
         artifact_id: str
             The identifier of the Hypha artifact to interact with
         """
-        self.artifact_alias = artifact_alias
-        self.workspace_id = workspace
+        if "/" in artifact_id:
+            self.workspace, self.artifact_alias = artifact_id.split("/")
+            if workspace:
+                assert workspace == self.workspace, "Workspace mismatch"
+        else:
+            self.workspace = workspace
+            self.artifact_alias = artifact_id
         self.token = token
-        self.artifact_url = "https://hypha.aicell.io/public/services/artifact-manager"
+        if service_url:
+            self.artifact_url = service_url
+        else:
+            self.artifact_url = "https://hypha.aicell.io/public/services/artifact-manager"
         self._client = None
 
     async def __aenter__(self: Self) -> Self:

--- a/hypha_artifact/hypha_artifact.py
+++ b/hypha_artifact/hypha_artifact.py
@@ -35,7 +35,7 @@ class HyphaArtifact:
         The base URL for the Hypha artifact manager service.
     token : str
         The authentication token for accessing the artifact service.
-    workspace_id : str
+    workspace : str
         The workspace identifier associated with the artifact.
 
     Examples
@@ -49,12 +49,7 @@ class HyphaArtifact:
     ...     f.write("new content")
     """
 
-    artifact_alias: str
-    artifact_url: str
-    token: str
-    workspace_id: str
-
-    def __init__(self: Self, artifact_alias: str, workspace: str, token: str):
+    def __init__(self: Self, artifact_id: str, workspace: str, token: str=None, service_url: str=None):
         """Initialize a HyphaArtifact instance.
 
         Parameters
@@ -62,10 +57,18 @@ class HyphaArtifact:
         artifact_id: str
             The identifier of the Hypha artifact to interact with
         """
-        self.artifact_alias = artifact_alias
-        self.workspace_id = workspace
+        if "/" in artifact_id:
+            self.workspace, self.artifact_alias = artifact_id.split("/")
+            if workspace:
+                assert workspace == self.workspace, "Workspace mismatch"
+        else:
+            self.workspace = workspace
+            self.artifact_alias = artifact_id
         self.token = token
-        self.artifact_url = "https://hypha.aicell.io/public/services/artifact-manager"
+        if service_url:
+            self.artifact_url = service_url
+        else:
+            self.artifact_url = "https://hypha.aicell.io/public/services/artifact-manager"
 
     def _extend_params(
         self: Self,
@@ -101,7 +104,7 @@ class HyphaArtifact:
             request_url,
             json=cleaned_params if json_data else None,
             params=cleaned_params if params else None,
-            headers={"Authorization": f"Bearer {self.token}"},
+            headers={"Authorization": f"Bearer {self.token}"} if self.token else None,
             timeout=20,
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=65.0.0", "wheel"]
 
 [project]
 name = "hypha-artifact"
-version = "0.0.4"
+version = "0.0.5"
 readme = "README.md"
 authors = [
   { name = "Hugo Dettner Källander", email = "hugokallander@gmail.com"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ description = "Hypha Artifact package, used with Hypha."
 requires-python = ">=3.11"
 dependencies = [
   "requests>=2.28.0",
+  "httpx",
   "python-dotenv>=0.21.0",
   "hypha_rpc>=0.20.54",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -149,7 +149,7 @@ class ArtifactTestMixin:
         """Test that the artifact is initialized correctly with real credentials."""
         assert artifact.artifact_alias == artifact_name
         assert artifact.token is not None
-        assert artifact.workspace_id is not None
+        assert artifact.workspace is not None
         assert artifact.artifact_url is not None
 
     def _validate_file_listing(self, files: list) -> None:

--- a/tests/test_async_hypha_artifact.py
+++ b/tests/test_async_hypha_artifact.py
@@ -202,7 +202,7 @@ class TestAsyncHyphaArtifactIntegration(ArtifactTestMixin):
         # Test that we can use the artifact within an async context
         async with AsyncHyphaArtifact(
             async_artifact.artifact_alias,
-            async_artifact.workspace_id,
+            async_artifact.workspace,
             async_artifact.token,
         ) as ctx_artifact:
             async with ctx_artifact.open(test_file_path, "w") as f:


### PR DESCRIPTION
This PR renames input argument artifact_alias to artifact_id so it can also contain workspace.


BTW @hugokallander I saw you used some class variables and thought you might be confused with the class instance variables. You might want to read here: https://programming-24.mooc.fi/part-9/5-class-attributes In our case, we shouldn't need to define it as a class variable, so I removed it. https://github.com/aicell-lab/hypha-artifact/compare/rename-artifact-id?expand=1#diff-a712a791cdd2bfa3fc9cbe940720511611b74210c2cd2845e2b636501d8eccd9L62-L66

 