### PR TITLE
Replace requests with httpx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Byte-compiled / optimized / DLL files
+.vscode/
 __pycache__/
 *.py[cod]
 *$py.class

--- a/docs/HyphaArtifact.md
+++ b/docs/HyphaArtifact.md
@@ -524,7 +524,7 @@ asyncio.run(main())
 
 Both `HyphaArtifact` and `AsyncHyphaArtifact` classes use HTTP requests to interact with the Hypha artifact service. Under the hood, they:
 
-1. Use the `requests` library (sync) or `aiohttp` library (async) to make HTTP requests
+1. Use the `httpx` library make HTTP requests
 2. Authenticate using a personal token
 3. Extract workspace information from the token
 4. Provide an fsspec-compatible interface for file operations

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,7 @@ authors = [
 description = "Hypha Artifact package, used with Hypha."
 requires-python = ">=3.11"
 dependencies = [
-  "requests>=2.28.0",
-  "httpx",
+  "httpx>=0.24.0",
   "python-dotenv>=0.21.0",
   "hypha_rpc>=0.20.54",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=65.0.0", "wheel"]
 
 [project]
 name = "hypha-artifact"
-version = "0.0.14"
+version = "0.0.15"
 readme = "README.md"
 authors = [
   { name = "Hugo Dettner Källander", email = "hugokallander@gmail.com"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-requests>=2.31.0
 httpx>=0.24.0


### PR DESCRIPTION
Currently requests cannot be used in pyodide 0.28.0 properly due to ssl error. This PR replace it with httpx entirely.

Fixes https://github.com/oeway/hypha-apps-cli/issues/6