### PR TITLE
Replace service_url to server_url

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ from hypha_artifact import HyphaArtifact
 artifact = HyphaArtifact(
     artifact_id="my-artifact",
     workspace="your-workspace-id", 
-    token="your-workspace-token"
+    token="your-workspace-token",
+    server_url="your-server-url"
 )
 
 # Stage changes to the artifact
@@ -129,6 +130,7 @@ async def main():
         artifact_id="my-artifact",
         workspace="your-workspace-id", 
         token="your-workspace-token"
+        server_url="your-server-url"
     ) as artifact:
         
         # Stage changes to the artifact
@@ -176,7 +178,7 @@ The `HyphaArtifact` class provides synchronous file operations:
 #### Initialization
 
 ```python
-HyphaArtifact(artifact_id: str, workspace: str, token: str)
+HyphaArtifact(artifact_id: str, workspace: str, token: str, server_url: str, use_proxy: bool)
 ```
 
 #### File Operations
@@ -194,7 +196,7 @@ HyphaArtifact(artifact_id: str, workspace: str, token: str)
 from hypha_artifact import HyphaArtifact
 
 # Initialize artifact
-artifact = HyphaArtifact("my-data", "workspace-123", "token-456")
+artifact = HyphaArtifact(artifact_id="my-data", workspace="workspace-123", token="token-456", server_url="your-server-url")
 
 # Stage changes before writing
 artifact.edit(stage=True)
@@ -255,7 +257,8 @@ from hypha_artifact import AsyncHyphaArtifact
 async_artifact = AsyncHyphaArtifact(
     artifact_id="my-artifact",
     workspace="workspace-id",
-    token="your-token"
+    token="your-token",
+    server_url="your-server-url"
 )
 ```
 
@@ -280,7 +283,7 @@ from hypha_artifact import AsyncHyphaArtifact
 
 async def main():
     # Method 1: Manual connection management
-    artifact = AsyncHyphaArtifact("my-workspace/my-artifact", token="token")
+    artifact = AsyncHyphaArtifact(artifact_id="my-workspace/my-artifact", token="token", workspace="my-workspace", server_url="your-server-url")
     
     await artifact.edit(stage=True)
     async with artifact.open("async_file.txt", "w") as f:
@@ -291,7 +294,7 @@ async def main():
     print(content)
     
     # Method 2: Context manager for the entire artifact
-    async with AsyncHyphaArtifact("my-artifact", "workspace", "token") as artifact:
+    async with AsyncHyphaArtifact(artifact_id="my-data", workspace="workspace-123", token="token-456", server_url="your-server-url") as artifact:
         # Stage, create, and commit
         await artifact.edit(stage=True)
         async with artifact.open("test.txt", "w") as f:
@@ -344,7 +347,7 @@ import asyncio
 from hypha_artifact import AsyncHyphaArtifact
 
 async def process_files():
-    async with AsyncHyphaArtifact("data-processing", "workspace", "token") as artifact:
+    async with AsyncHyphaArtifact(artifact_id="my-data", workspace="workspace-123", token="token-456", server_url="your-server-url") as artifact:
         
         # Stage changes before creating files
         await artifact.edit(stage=True)
@@ -385,7 +388,7 @@ The library provides powerful methods for transferring files between local files
 ```python
 from hypha_artifact import HyphaArtifact
 
-artifact = HyphaArtifact("my-artifact", "workspace", "token")
+artifact = HyphaArtifact(artifact_id="my-artifact", workspace="workspace", token="token", server_url="your-server-url")
 
 # Copy a single file from remote to local
 artifact.get("remote_file.txt", "local_file.txt")
@@ -423,7 +426,7 @@ import asyncio
 from hypha_artifact import AsyncHyphaArtifact
 
 async def transfer_files():
-    async with AsyncHyphaArtifact("my-artifact", "workspace", "token") as artifact:
+    async with AsyncHyphaArtifact(artifact_id="my-data", workspace="workspace-123", token="token-456", server_url="your-server-url") as artifact:
         
         # Copy files from remote to local
         await artifact.get("remote_file.txt", "local_file.txt")
@@ -494,7 +497,7 @@ async with artifact.open("large_file.txt", "r") as f:
 ```python
 from hypha_artifact import HyphaArtifact
 
-artifact = HyphaArtifact("my-artifact", "workspace", "token")
+artifact = HyphaArtifact(artifact_id="my-data", workspace="workspace-123", token="token-456", server_url="your-server-url")
 
 try:
     # Try to read a non-existent file

--- a/hypha_artifact/async_hypha_artifact/__init__.py
+++ b/hypha_artifact/async_hypha_artifact/__init__.py
@@ -77,7 +77,7 @@ class AsyncHyphaArtifact:
         artifact_id: str,
         workspace: str | None = None,
         token: str | None = None,
-        service_url: str | None = None,
+        server_url: str | None = None,
         use_proxy: bool | None = None,
     ):
         """Initialize an AsyncHyphaArtifact instance."""
@@ -92,11 +92,11 @@ class AsyncHyphaArtifact:
             self.workspace = workspace
             self.artifact_alias = artifact_id
         self.token = token
-        if service_url:
-            self.artifact_url = service_url
+        if server_url:
+            self.artifact_url = f"{server_url}/public/services/artifact-manager"
         else:
-            self.artifact_url = (
-                "https://hypha.aicell.io/public/services/artifact-manager"
+            raise ValueError(
+                "Server URL must be provided, e.g. https://hypha.aicell.io"
             )
         self._client = None
 

--- a/hypha_artifact/hypha_artifact.py
+++ b/hypha_artifact/hypha_artifact.py
@@ -38,8 +38,8 @@ class HyphaArtifact:
         The workspace identifier associated with the artifact.
     token : str | None
         The authentication token for accessing the artifact service.
-    service_url : str | None
-        The base URL for the Hypha artifact manager service.
+    server_url : str | None
+        The base URL for the Hypha server.
     use_proxy : bool | None
         Whether to use a proxy for HTTP requests.
 
@@ -63,7 +63,7 @@ class HyphaArtifact:
         artifact_id: str,
         workspace: str | None = None,
         token: str | None = None,
-        service_url: str | None = None,
+        server_url: str | None = None,
         use_proxy: bool | None = None,
     ):
         """Initialize a HyphaArtifact instance.
@@ -74,7 +74,7 @@ class HyphaArtifact:
             The identifier of the Hypha artifact to interact with
         """
         self._async_artifact = AsyncHyphaArtifact(
-            artifact_id, workspace, token, service_url, use_proxy=use_proxy
+            artifact_id, workspace, token, server_url, use_proxy=use_proxy
         )
 
     def edit(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=65.0.0", "wheel"]
 
 [project]
 name = "hypha-artifact"
-version = "0.0.15"
+version = "0.0.16"
 readme = "README.md"
 authors = [
   { name = "Hugo Dettner Källander", email = "hugokallander@gmail.com"}

--- a/tests/test_async_hypha_artifact.py
+++ b/tests/test_async_hypha_artifact.py
@@ -21,7 +21,9 @@ async def get_async_artifact(
 ) -> Any:
     """Create a test artifact with a real async connection to Hypha."""
     token, workspace = artifact_setup_teardown
-    artifact = AsyncHyphaArtifact(artifact_name, workspace, token)
+    artifact = AsyncHyphaArtifact(
+        artifact_name, workspace, token, server_url="https://hypha.aicell.io"
+    )
     yield artifact
     await artifact.aclose()
 
@@ -237,6 +239,7 @@ class TestAsyncHyphaArtifactIntegration(ArtifactTestMixin):
             async_artifact.artifact_alias,
             async_artifact.workspace,
             async_artifact.token,
+            server_url="https://hypha.aicell.io",
         ) as ctx_artifact:
             await ctx_artifact.edit(stage=True)
             async with ctx_artifact.open(test_file_path, "w") as f:

--- a/tests/test_hypha_artifact.py
+++ b/tests/test_hypha_artifact.py
@@ -17,7 +17,7 @@ from hypha_artifact import HyphaArtifact
 def get_artifact(artifact_name: str, artifact_setup_teardown: tuple[str, str]) -> Any:
     """Create a test artifact with a real connection to Hypha."""
     token, workspace = artifact_setup_teardown
-    return HyphaArtifact(artifact_name, workspace, token)
+    return HyphaArtifact(artifact_name, workspace, token, server_url="https://hypha.aicell.io")
 
 
 class TestHyphaArtifactIntegration(ArtifactTestMixin):

--- a/tests/test_unit_async_hypha_artifact.py
+++ b/tests/test_unit_async_hypha_artifact.py
@@ -13,7 +13,7 @@ from hypha_artifact import AsyncHyphaArtifact
 def get_async_artifact(mocker: MockerFixture) -> AsyncHyphaArtifact:
     """Create a test artifact with a mocked async client."""
     mocker.patch("hypha_artifact.async_hypha_artifact.httpx.AsyncClient")
-    return AsyncHyphaArtifact("test-artifact", "test-workspace")
+    return AsyncHyphaArtifact("test-artifact", "test-workspace", server_url="https://hypha.aicell.io")
 
 
 class TestAsyncHyphaArtifactUnit:

--- a/tests/test_unit_hypha_artifact.py
+++ b/tests/test_unit_hypha_artifact.py
@@ -15,7 +15,7 @@ def get_artifact(mocker: MockerFixture) -> HyphaArtifact:
     mock_async_artifact = mocker.patch(
         "hypha_artifact.hypha_artifact.AsyncHyphaArtifact"
     )
-    artifact = HyphaArtifact("test-artifact", "test-workspace")
+    artifact = HyphaArtifact("test-artifact", "test-workspace", server_url="https://hypha.aicell.io")
     artifact._async_artifact = mock_async_artifact.return_value
     return artifact
 


### PR DESCRIPTION
This PR replace service_url to server_url which is more standard for hypha related services.
And we remove the default server_url, so the user need to explicitly specify it.

Closes #10 
